### PR TITLE
可以显示商品详情页了

### DIFF
--- a/df_goods/models.py
+++ b/df_goods/models.py
@@ -31,6 +31,10 @@ class GoodsManager(BaseManager):
             goods_list = goods_list[:limit]
         return goods_list
 
+    def get_goods_by_id(self, goods_id):
+        '''根据商品id查询商品信息'''
+        obj = self.get_one_object(id=goods_id)
+        return obj
 
 class Goods(BaseModel):
     '''商品模型类'''
@@ -67,3 +71,30 @@ class Goods(BaseModel):
         db_table = 's_goods'
 
 
+class ImageManager(BaseManager):
+    '''商品详情图片管理器类'''
+    def get_image_by_goods_id(self, goods_id): # 61
+        '''根据商品的id查询商品详情图片'''
+        images = self.get_object_list(filters={'goods_id':goods_id}) # 返回值是一个查询集
+        if images.exists():
+            # 查询集中有图片数据
+            # 取出images查询集中的第一个元素，重新赋值给images
+            # 此时images对象的类型为Image
+            images = images[0]
+        else:
+            # 查询集中没有图片
+            # 此时images的类型为QuerySet,给images增加一个属性img_url,防止出错
+            images.img_url = ''
+        # 返回images,返回的类型可能是Image或这QuerySet,但都有img_url属性
+        return images
+
+
+class Image(BaseModel):
+    '''商品详情图片模型类'''
+    goods = models.ForeignKey('Goods', verbose_name='所属商品')
+    img_url = models.ImageField(upload_to='goods', verbose_name='图片路径')
+
+    objects = ImageManager()
+
+    class Meta:
+        db_table = 's_goods_image'

--- a/df_goods/urls.py
+++ b/df_goods/urls.py
@@ -5,6 +5,7 @@ from df_goods import views
 
 urlpatterns = [
     url(r'^$', views.home_list_page),  # 显示首页
+    url(r'^goods/(?P<goods_id>\d+)/$', views.goods_detail),  # 显示商品详情页面
 
 ]
 

--- a/df_goods/views.py
+++ b/df_goods/views.py
@@ -1,5 +1,5 @@
 from django.shortcuts import render
-from df_goods.models import Goods
+from df_goods.models import Goods, Image
 from df_goods.enums import *
 
 # Create your views here.
@@ -35,3 +35,13 @@ def home_list_page(request):
         'frozen': frozen, 'frozen_new': frozen_new,
     }
     return render(request, 'df_goods/index.html', context)
+
+
+def goods_detail(request, goods_id):
+    # 根据商品id获取商品信息
+    goods = Goods.objects.get_goods_by_id(goods_id=goods_id)
+    # 根据商品类型查询新品信息
+    # 根据商品id查询出一张商品的详情图片
+    images = Image.objects.get_image_by_goods_id(goods_id=goods_id)
+    goods_new = Goods.objects.get_goods_by_type(goods_type_id=goods.goods_type_id, limit=2, sort='new')
+    return render(request,'df_goods/detail.html', {'goods': goods, 'goods_new': goods_new, 'images': images})

--- a/templates/df_goods/detail.html
+++ b/templates/df_goods/detail.html
@@ -1,0 +1,106 @@
+{% extends 'base_detail_list.html' %}
+{% load staticfiles %}
+{% block title %}天天生鲜-商品详情{% endblock title %}
+
+    {% block main_content %}
+
+
+	    <div class="breadcrumb">
+		<a href="#">全部分类</a>
+		<span>></span>
+		<a href="#">新鲜水果</a>
+		<span>></span>
+		<a href="#">商品详情</a>
+	</div>
+
+	    <div class="goods_detail_con clearfix">
+		<div class="goods_detail_pic fl"><img src="{% static images.img_url %}"></div>
+
+		<div class="goods_detail_list fr">
+			<h3>{{ goods.goods_name }}</h3>
+			<p>{{ goods.goods_sub_title }}</p>
+			<div class="prize_bar">
+				<span class="show_pirze">¥<em>{{ goods.goods_price }}</em></span>
+				<span class="show_unit">单  位：{{ goods.goods_unite }}</span>
+			</div>
+			<div class="goods_num clearfix">
+				<div class="num_name fl">数 量：</div>
+				<div class="num_add fl">
+					<input type="text" class="num_show fl" value="1">
+					<a href="javascript:;" class="add fr">+</a>
+					<a href="javascript:;" class="minus fr">-</a>
+				</div>
+			</div>
+			<div class="total">总价：<em>16.80元</em></div>
+			<div class="operate_btn">
+				<a href="javascript:;" class="buy_btn">立即购买</a>
+				<a href="javascript:;" class="add_cart" id="add_cart">加入购物车</a>
+			</div>
+		</div>
+	</div>
+
+	    <div class="main_wrap clearfix">
+		<div class="l_wrap fl clearfix">
+			<div class="new_goods">
+				<h3>新品推荐</h3>
+				<ul>
+                    {% for foo in goods_new %}
+                        <li>
+						    <a href="#"><img src="{% static foo.goods_image %}"></a>
+						    <h4><a href="#">{{ foo.goods_name }}</a></h4>
+						    <div class="prize">￥{{ foo.goods_price }}</div>
+					    </li>
+                    {% endfor %}
+				</ul>
+			</div>
+		</div>
+
+		<div class="r_wrap fr clearfix">
+			<ul class="detail_tab clearfix">
+				<li class="active">商品介绍</li>
+				<li>评论</li>
+			</ul>
+
+			<div class="tab_content">
+				<dl>
+					<dt>商品详情：</dt>
+					<dd>{{ goods.goods_info |safe }} </dd>
+				</dl>
+			</div>
+
+		</div>
+	</div>
+
+
+    {% endblock main_content %}
+
+
+    {# 网页底部html内容块 #}
+    {% block bottom %}
+        <div class="add_jump"></div>
+    {% endblock bottom %}
+    {# 网页底部引入文件块 #}
+	{% block bottomfiles %}
+        <script type="text/javascript" src="js/jquery-1.12.2.js"></script>
+	    <script type="text/javascript">
+		var $add_x = $('#add_cart').offset().top;
+		var $add_y = $('#add_cart').offset().left;
+
+		var $to_x = $('#show_count').offset().top;
+		var $to_y = $('#show_count').offset().left;
+
+		$(".add_jump").css({'left':$add_y+80,'top':$add_x+10,'display':'block'})
+		$('#add_cart').click(function(){
+			$(".add_jump").stop().animate({
+				'left': $to_y+7,
+				'top': $to_x+7},
+				"fast", function() {
+					$(".add_jump").fadeOut('fast',function(){
+						$('#show_count').html(2);
+					});
+
+			});
+		})
+	</script>
+	{% endblock bottomfiles %}
+

--- a/templates/df_goods/index.html
+++ b/templates/df_goods/index.html
@@ -54,7 +54,7 @@
 			<div class="subtitle fl">
 				<span>|</span>
                 {% for foo in fruits_new %}
-                    <a href="#">{{ foo.goods_name }}</a>
+                    <a href="/goods/{{ foo.id }}/">{{ foo.goods_name }}</a>
                 {% endfor %}
 			</div>
 			<a href="#" class="goods_more fr" id="fruit_more">查看更多 ></a>
@@ -65,8 +65,8 @@
 			<ul class="goods_list fl">
                 {% for fruit in fruits %}
                     <li>
-					    <h4><a href="#">{{ fruit.goods_name }}</a></h4>
-					    <a href="#"><img src="{% static fruit.goods_image %}"></a>
+					    <h4><a href="/goods/{{ fruit.id }}/">{{ fruit.goods_name }}</a></h4>
+					    <a href="/goods/{{ fruit.id }}/"><img src="{% static fruit.goods_image %}"></a>
 					    <div class="prize">¥ {{ fruit.goods_price }}</div>
 				    </li>
                 {% endfor %}
@@ -80,7 +80,7 @@
 			<div class="subtitle fl">
 				<span>|</span>
                 {% for foo in seafood_new %}
-                    <a href="#">{{ foo.goods_name }}</a>
+                    <a href="/goods/{{ foo.id }}/">{{ foo.goods_name }}</a>
                 {% endfor %}
 			</div>
 			<a href="#" class="goods_more fr">查看更多 ></a>
@@ -91,8 +91,8 @@
 			<ul class="goods_list fl">
                 {% for foo in seafood %}
                     <li>
-					    <h4><a href="#">{{ foo.goods_name }}</a></h4>
-					    <a href="#"><img src="{% static foo.goods_image %}"></a>
+					    <h4><a href="/goods/{{ foo.id }}/">{{ foo.goods_name }}</a></h4>
+					    <a href="/goods/{{ foo.id }}/"><img src="{% static foo.goods_image %}"></a>
 					    <div class="prize">¥ {{ foo.goods_price }}</div>
 				    </li>
                 {% endfor %}


### PR DESCRIPTION
商品详情页显示原理，点击商品图片或名称，请求 /goods/goods_id/  页面，
路由：   url(r'^goods/(?P<goods_id>\d+)/$', views.goods_detail),  # 显示商品详情页面
视图： 
def goods_detail(request, goods_id):
    # 根据商品id获取商品信息
    goods = Goods.objects.get_goods_by_id(goods_id=goods_id)
模型:
    def get_goods_by_id(self, goods_id):
        '''根据商品id查询商品信息'''
        obj = self.get_one_object(id=goods_id)
        return obj

由于商品和商品图片具有一对多的关系，建立商品图片表并根据商品id获取商品图片
    def get_image_by_goods_id(self, goods_id): # 61
        '''根据商品的id查询商品详情图片'''
        images = self.get_object_list(filters={'goods_id':goods_id}) # 返回值是一个查询集
        if images.exists():
            # 查询集中有图片数据
            # 取出images查询集中的第一个元素，重新赋值给images
            # 此时images对象的类型为Image
            images = images[0]
        else:
            # 查询集中没有图片
            # 此时images的类型为QuerySet,给images增加一个属性img_url,防止出错
            images.img_url = ''
        # 返回images,返回的类型可能是Image或这QuerySet,但都有img_url属性
        return images